### PR TITLE
use meta noidex to prevent search indexing of ph-submissions preview

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -13,6 +13,8 @@
 
     <link href='https://programminghistorian.org/feed.xml' rel='alternate' type='application/atom+xml'>
 
+    <meta name="robots" content="Noindex">
+
     <title>{{ page.title }} | {{ site.name }}</title>
 
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
@@ -36,7 +38,7 @@
       article {
           counter-reset: paragraph;
       }
-  
+
       .content p:after {
            position: absolute;
            right: 0.6em;


### PR DESCRIPTION
re: https://github.com/programminghistorian/jekyll/issues/896